### PR TITLE
Fix Git GUI in Git for Windows 2.x

### DIFF
--- a/git-gui.sh
+++ b/git-gui.sh
@@ -270,12 +270,10 @@ proc is_Windows {} {
 proc is_Cygwin {} {
 	global _iscygwin
 	if {$_iscygwin eq {}} {
-		if {$::tcl_platform(platform) eq {windows}} {
-			if {[catch {set p [exec cygpath --windir]} err]} {
-				set _iscygwin 0
-			} else {
-				set _iscygwin 1
-			}
+		if {$::tcl_platform(platform) eq {windows} &&
+				(![info exists ::env(MSYSTEM)] ||
+				 $::env(MSYSTEM) ne {MSYS})} {
+			set _iscygwin 1
 		} else {
 			set _iscygwin 0
 		}

--- a/lib/shortcut.tcl
+++ b/lib/shortcut.tcl
@@ -11,11 +11,17 @@ proc do_windows_shortcut {} {
 		if {[file extension $fn] ne {.lnk}} {
 			set fn ${fn}.lnk
 		}
+		# Use /cmd/git-gui.exe if available
+		set normalized [file normalize $::argv0]
+		regsub "/mingw../libexec/git-core/git-gui$" \
+			$normalized "/cmd/git-gui.exe" cmdLine
+		if {$cmdLine != $normalized && [file exists $cmdLine]} {
+			set cmdLine [list [file nativename $cmdLine]]
+		} else {
+			set cmdLine [list [info nameofexecutable] $normalized]
+		}
 		if {[catch {
-				win32_create_lnk $fn [list \
-					[info nameofexecutable] \
-					[file normalize $::argv0] \
-					] \
+				win32_create_lnk $fn $cmdLine \
 					[file normalize $_gitworktree]
 			} err]} {
 			error_popup [strcat [mc "Cannot write shortcut:"] "\n\n$err"]


### PR DESCRIPTION
With the switch to 2.x, Git for Windows started relying on MSys2
instead of MSys. This also implies that we now have the `cygpath`
tool that was formerly used to determine whether we're running
Cygwin or MinGW/MSys.

Another issue: the code behind Repository>Create Desktop Icon
generated a `.lnk` file that fails to launch the Git GUI in Git
for Windows 2.x.

This topic branch fixes both bugs.
