### PR TITLE
git gui: fix staging a second line to a 1-line file

### DIFF
--- a/lib/diff.tcl
+++ b/lib/diff.tcl
@@ -698,6 +698,7 @@ proc apply_range_or_line {x y} {
 		set hh [$ui_diff get $i_l "$i_l + 1 lines"]
 		set hh [lindex [split $hh ,] 0]
 		set hln [lindex [split $hh -] 1]
+		set hln [lindex [split $hln " "] 0]
 
 		# There is a special situation to take care of. Consider this
 		# hunk:


### PR DESCRIPTION
When a 1-line file is augmented by a second line, and the user tries to
stage that single line via the "Stage Line" context menu item, we do not
want to see "apply: corrupt patch at line 5".

The reason for this error was that the hunk header looks like this:

```
@@ -1 +1,2 @@
```

but the existing code expects the original range always to contain a
comma. This problem is easily fixed by cutting the string "1 +1,2"
(that Git GUI formerly mistook for the starting line) at the space.

This fixes https://github.com/git-for-windows/git/issues/515

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
