### PR TITLE
respect core.hooksPath, falling back to .git/hooks

### DIFF
--- a/git-gui.sh
+++ b/git-gui.sh
@@ -624,7 +624,10 @@ proc git_write {args} {
 }
 
 proc githook_read {hook_name args} {
-	set pchook [gitdir hooks $hook_name]
+	if {[catch {set hooksdir [git config core.hooksPath]}]} {
+		set hooksdir [gitdir hooks]
+	}
+	set pchook [file join $hooksdir $hook_name]
 	lappend args 2>@1
 
 	# On Windows [file executable] might lie so we need to ask


### PR DESCRIPTION
The following patch tries to fix git-gui to respect the core.hooksPath config
variable, falling back to the old behavior.
