### PR TITLE
git-gui: compensate the additional diff marker at line start

### DIFF
--- a/lib/diff.tcl
+++ b/lib/diff.tcl
@@ -6,7 +6,7 @@ proc apply_tab_size {{firsttab {}}} {
 
 	set w [font measure font_diff "0"]
 	if {$have_tk85 && $firsttab != 0} {
-		$ui_diff configure -tabs [list [expr {$firsttab * $w}] [expr {($firsttab + $repo_config(gui.tabsize)) * $w}]]
+		$ui_diff configure -tabs [list [expr {($firsttab + $repo_config(gui.tabsize)) * $w}] [expr {($firsttab + 2*$repo_config(gui.tabsize)) * $w}]]
 	} elseif {$have_tk85 || $repo_config(gui.tabsize) != 8} {
 		$ui_diff configure -tabs [expr {$repo_config(gui.tabsize) * $w}]
 	} else {
@@ -118,7 +118,7 @@ proc show_diff {path w {lno {}} {scroll_pos {}} {callback {}}} {
 
 	set cont_info [list $scroll_pos $callback]
 
-	apply_tab_size 0
+	apply_tab_size 1
 
 	if {[string first {U} $m] >= 0} {
 		merge_load_stages $path [list show_unmerged_diff $cont_info]
@@ -420,7 +420,7 @@ proc read_diff {fd conflict_size cont_info} {
 		#
 		if {[string match {@@@ *} $line]} {
 			set is_3way_diff 1
-			apply_tab_size 1
+			apply_tab_size 2
 		}
 
 		if {$::current_diff_inheader} {


### PR DESCRIPTION
Let `apply_tab_size` increase the size of the first tab by 1 unless a 3 way diff is detected (by 2). This compensates for the additional diff marker at the line start.

The original code creates equidistant tab stops for normal diffs (`firsttab==0`), and for a 3 way diff a first tabstop at column `firsttab==1`. Apart from that it's a  great tool!

