### PR TITLE
Replace Free Software Foundation address in license notices

### DIFF
--- a/git-gui.sh
+++ b/git-gui.sh
@@ -24,8 +24,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA}]
+along with this program; if not, see <http://www.gnu.org/licenses/>.}]
 
 ######################################################################
 ##


### PR DESCRIPTION
The mailing address for the FSF has changed over the years.  Rather than
updating the address across all files, refer readers to gnu.org, as the
GNU GPL documentation now suggests for license notices.  The mailing
address is retained in the full license files (COPYING and LGPL-2.1).

Signed-off-by: Todd Zullinger <tmz@pobox.com>
Signed-off-by: Junio C Hamano <gitster@pobox.com>

--
Pat, I'll be queuing this together with https://public-inbox.org/git/20171107053933.23370-1-tmz@pobox.com to my tree, by pretending that you accepted this pull request and I merged the result from you.

Thanks.

