### PR TITLE
git-gui: search for all current SSH key types

### DIFF
--- a/lib/sshkey.tcl
+++ b/lib/sshkey.tcl
@@ -2,7 +2,10 @@
 # Copyright (C) 2006, 2007 Shawn Pearce
 
 proc find_ssh_key {} {
-	foreach name {~/.ssh/id_dsa.pub ~/.ssh/id_rsa.pub ~/.ssh/identity.pub} {
+	foreach name {
+		~/.ssh/id_dsa.pub ~/.ssh/id_ecdsa.pub ~/.ssh/id_ed25519.pub
+		~/.ssh/id_rsa.pub ~/.ssh/identity.pub
+	} {
 		if {[file exists $name]} {
 			set fh    [open $name r]
 			set cont  [read $fh]


### PR DESCRIPTION
This is <20180224183913.8345-1-dev+git@drbeat.li>, which I tentatively queued to 'pu'.

